### PR TITLE
First font attempt

### DIFF
--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -38,11 +38,16 @@
   src: url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-BlackCond.woff2") format("woff2"),
 }
 
+@font-face {
+  font-family: "HelveticaNeue Roman";
+  src: url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Roman.woff2") format("woff2");
+}
+
 $skin-font-family-primary: "Helvetica 57 Condensed", sans-serif !default;
 $skin-font-family-secondary: "Helvetica 47 Light Condensed", sans-serif !default;
 
 $theme-item-title-font-family: "HelveticaNeue 97 Black Condensed", sans-serif;;
-
+$theme-content-body-font: "HelveticaNeue Roman", sans-serif;
 // Override monorails typography font families
 $typography: (
   "header-1": (
@@ -55,11 +60,16 @@ $typography: (
     "font-family": $theme-item-title-font-family,
     "text-transform": uppercase,
   ),
+  "header-3": (
+    "font-family": $theme-item-title-font-family,
+  ),
   "article-text": (
+    "font-family": $theme-content-body-font,
     "line-height": 1.125,
     "font-size": 16px,
   ),
   "small-body-text": (
+    "font-family": $theme-content-body-font,
     "line-height": 1.125,
     "font-size": 14px,
   ),

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -1,13 +1,89 @@
+// @font-face {
+//   font-family: "Fira Sans-fallback";
+//   size-adjust: 102.56%;
+//   ascent-override: 92%;
+//   src: local("Arial");
+// }
+
+// // Fonts
+// $skin-font-family-primary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
+// $skin-font-family-secondary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
+
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/74fc282ac1937b053f409b3b70eb1bb6.woff2?family-family=Helvetica+Rand1");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/d72e521f27450184733d89aa499e531c.woff2?family=Helvetica+Rand2");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/helvetica-47-light-condensed-587ebd7b5a6f6.woff2");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-75Bold.woff2?family=HelveticaNeue+75+Bold");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Black.woff2?font-family=HelveticaNeue+Black?display=swap");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-BlackCond.woff2?family-family=helvetica-neue-97-black-condensed");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Condensed.woff2?family=HelveticaNeue+Condesed");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Medium.woff?family=HelveticaNeue+Medium");
+// @import url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Roman.woff2?family=HelveticaNeue+Roman&display=swap");
+
 @font-face {
-  font-family: "Fira Sans-fallback";
-  size-adjust: 102.56%;
-  ascent-override: 92%;
-  src: local("Arial");
+  font-family: 'Helvetica 47 Light Condensed';
+  font-weight: 400;
+  font-style: normal;
+  src: url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/helvetica-47-light-condensed-587ebd7b5a6f6.woff2") format('woff2');
+  font-display: swap
 }
 
-// Fonts
-$skin-font-family-primary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
-$skin-font-family-secondary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
+@font-face {
+  font-family: "Helvetica 57 Condensed";
+  src: url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-Condensed.woff2") format("woff2"),
+}
+
+// Content Header Font Inclusion
+@font-face {
+  font-family:"HelveticaNeue 97 Black Condensed";
+  src: url("https://img.forconstructionpros.com/files/base/bonhill/all/fonts/helvetica/HelveticaNeue-BlackCond.woff2") format("woff2"),
+}
+
+$skin-font-family-primary: "Helvetica 57 Condensed", sans-serif !default;
+$skin-font-family-secondary: "Helvetica 47 Light Condensed", sans-serif !default;
+
+$theme-item-title-font-family: "HelveticaNeue 97 Black Condensed", sans-serif;;
+
+// Override monorails typography font families
+$typography: (
+  "header-1": (
+    "font-family": $theme-item-title-font-family,
+  ),
+  "header-1.5": (
+    "font-family": $theme-item-title-font-family,
+  ),
+  "article-text": (
+    "line-height": 1.125,
+    "font-size": 16px,
+  ),
+  "small-body-text": (
+    "line-height": 1.125,
+    "font-size": 14px,
+  ),
+  "teaser-text-1": (
+    "line-height": 1.125,
+    "font-size": 16px,
+  ),
+  "slug-medium": (
+    "font-family": $theme-item-title-font-family,
+    "line-height": 1.1125,
+    "font-size": 12px,
+  ),
+  "section-header": (
+    "font-family": $theme-item-title-font-family,
+  ),
+  "section-header-small": (
+    "font-family": $theme-item-title-font-family,
+  )
+  // DROP DOWN MENU PROPs
+  // "menu-item-primary": (
+  //   "font-family": $theme-item-title-font-family,
+  // ),
+  // "menu-item-secondary": (
+  //   "font-size": 50px,
+  //   "font-family": $theme-item-title-font-family,
+  // ),
+);
+
 // Only set to override the 700px max.  Need to figure out how to remove this all together.
 $skin-content-body-max-width: 1000px;
 
@@ -25,3 +101,5 @@ $theme-card-header-text-transform: uppercase !default;
 // Ads
 $leaderboard-min-height-mobile: 100px !default;
 $leaderboard-min-height-desktop: 90px !default;
+
+// $skin-content-body-max-width: auto;

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -8,6 +8,8 @@
 // Fonts
 $skin-font-family-primary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
 $skin-font-family-secondary: "Fira Sans", "Fira Sans-fallback", sans-serif !default;
+// Only set to override the 700px max.  Need to figure out how to remove this all together.
+$skin-content-body-max-width: 1000px;
 
 // Navbar
 $navbarStyle: "navbar-c" !default;

--- a/packages/global/scss/_variables.scss
+++ b/packages/global/scss/_variables.scss
@@ -51,6 +51,10 @@ $typography: (
   "header-1.5": (
     "font-family": $theme-item-title-font-family,
   ),
+  "header-2": (
+    "font-family": $theme-item-title-font-family,
+    "text-transform": uppercase,
+  ),
   "article-text": (
     "line-height": 1.125,
     "font-size": 16px,
@@ -71,7 +75,7 @@ $typography: (
   "section-header": (
     "font-family": $theme-item-title-font-family,
   ),
-  "section-header-small": (
+  "section-header-small__header": (
     "font-family": $theme-item-title-font-family,
   )
   // DROP DOWN MENU PROPs

--- a/packages/global/scss/components/_site-navbar-c.scss
+++ b/packages/global/scss/components/_site-navbar-c.scss
@@ -113,6 +113,7 @@
     &__items {
       &--primary {
         font-size: 13px;
+        font-family: $theme-item-title-font-family;
       }
     }
     &--secondary {

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -531,3 +531,10 @@ label {
     }
   }
 }
+
+
+@media (min-width: 1080px) {
+  .document-container {
+    max-width: 1300px;
+  }
+}

--- a/packages/global/scss/core.scss
+++ b/packages/global/scss/core.scss
@@ -532,7 +532,7 @@ label {
   }
 }
 
-
+// Override default container width
 @media (min-width: 1080px) {
   .document-container {
     max-width: 1300px;


### PR DESCRIPTION
Update included fonts and set typography with new fonts

Ill have to clean up the commented out fonts, but this is for reference to fonts they currently have on their sites.

Applied font-family, line-height & font-size overrides to the current typography prop for things like the title, section names, body copy(reg & small).

```
$typography: (
  "header-1": (
    "font-family": $theme-item-title-font-family,
  ),
  "header-1.5": (
    "font-family": $theme-item-title-font-family,
  ),
  "article-text": (
    "line-height": 1.125,
    "font-size": 16px,
  ),
  "small-body-text": (
    "line-height": 1.125,
    "font-size": 14px,
  ),
  "teaser-text-1": (
    "line-height": 1.125,
    "font-size": 16px,
  ),
  "slug-medium": (
    "font-family": $theme-item-title-font-family,
    "line-height": 1.1125,
    "font-size": 12px,
  ),
  "section-header": (
    "font-family": $theme-item-title-font-family,
  ),
  "section-header-small": (
    "font-family": $theme-item-title-font-family,
  )
  // DROP DOWN MENU PROPs
  // "menu-item-primary": (
  //   "font-family": $theme-item-title-font-family,
  // ),
  // "menu-item-secondary": (
  //   "font-size": 50px,
  //   "font-family": $theme-item-title-font-family,
  // ),
);
```
<img width="1375" alt="Screen Shot 2022-11-04 at 12 05 36 PM" src="https://user-images.githubusercontent.com/3845869/200035560-263b9285-6b4c-482a-a41a-f4ecaa84485c.png">


![bonhill-content-page](https://user-images.githubusercontent.com/3845869/200035509-4c52067d-1aba-4b12-abed-9f0f8a9bcd04.jpg)

